### PR TITLE
docs: improve manual wrapper installation instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -263,11 +263,11 @@ avc-parser --file /var/log/audit/audit.log --report brief
    **Without make:**
    ```bash
    # Manual installation to ~/bin (no sudo required)
+   # Note: Run these commands from within the avc-parser directory
    mkdir -p ~/bin
-   cat > ~/bin/avc-parser << 'EOF'
+   cat > ~/bin/avc-parser << EOF
    #!/bin/bash
-   cd /path/to/avc-parser
-   exec python3 parse_avc.py "$@"
+   exec python3 $(pwd)/parse_avc.py "\$@"
    EOF
    chmod +x ~/bin/avc-parser
 


### PR DESCRIPTION
Improves the manual installation instructions in the README to align with the wrapper fix from PR #2.

**Changes:**
- Add clarification to run commands from within the avc-parser directory
- Use `$(pwd)` to capture the current directory instead of placeholder `/path/to/avc-parser`
- Change from quoted `'EOF'` to unquoted `EOF` to allow variable expansion
- Ensures `$@` is properly escaped in the heredoc

This complements the excellent fix by @sayan3296 in PR #2 which resolved issue #1 (wrapper not preserving PWD). The manual installation now works the same way as `make install-wrapper`.

**References:**
- Fixes manual installation consistency after PR #2
- Related to #1